### PR TITLE
Add multi_json as a dependency to the gemspec

### DIFF
--- a/padrino-multi-json.gemspec
+++ b/padrino-multi-json.gemspec
@@ -17,5 +17,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]  
+  s.require_paths = ["lib"]
+  
+  s.add_dependency 'multi_json', '~> 1.0'
 end


### PR DESCRIPTION
- multi_json is required in padrino-multi-json.rb:1.
